### PR TITLE
chore: add .env file loading support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,8 @@ yarn-error.*
 .DS_Store
 *.pem
 
-# local env files
-.env*.local
+# Env files
+.env*
 
 # typescript
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -42,7 +42,19 @@ The purpose of this server is to provide MAD course students with a real-world e
    npm start
    ```
 
-The server will start running on `http://localhost:3000/`. Adjust the port in the configuration if necessary.
+   The server will start running on `http://localhost:3000/`. Adjust the port in the configuration if necessary.
+
+5. **(Optional) Change the Server Port**
+
+    1. Make a copy of the `example.env` file in the project's root directory and rename it to `.env`.
+    2. Set the `PORT` environment variable value to the desired port.
+
+    e.g.
+    `.env`:
+
+    ```env
+    PORT=3001
+    ```
 
 ## Features
 

--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 var createError = require("http-errors");
 var express = require("express");
 var path = require("path");
@@ -57,7 +58,7 @@ if (process.env.NODE_ENV !== "test") {
   setTimeout(() => {
     console.log(
       "\x1b[32m%s\x1b[0m",
-      "\nFake store server started. Visit http://localhost:3000/ for API documentation.\n"
+      `\nFake store server started. Visit http://localhost:${process.env.PORT || '3000'}/ for API documentation.\n`
     );
   }, 1000);
 }

--- a/example.env
+++ b/example.env
@@ -1,0 +1,5 @@
+# Example of .env file for the project, showing the available variables and their default values
+# If required, copy this file and rename it to .env, then fill in the desired values
+
+# The port on which the server will listen (defaults to 3000)
+PORT=

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
         "debug": "~2.6.9",
+        "dotenv": "^16.4.5",
         "express": "~4.16.1",
         "http-errors": "~1.6.3",
         "jade": "~1.11.0",
@@ -2308,6 +2309,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecdsa-sig-formatter": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",
+    "dotenv": "^16.4.5",
     "express": "~4.16.1",
     "http-errors": "~1.6.3",
     "jade": "~1.11.0",


### PR DESCRIPTION
This small PR adds support for cross-platform `.env` file loading in the project, allowing the server port to be configured more easily.

The following minor changes have been made in order to achieve this:

* `dotenv` library has been added to project dependencies and imported in `app.js`.
* The "Server started" console.log message in `app.js` has been updated in order to correctly output the port the server is currently running on. (The previous output was a static string, "`3000`")
* The `Setup` portion of the project's `README.md` has been extended to include instructions for the additional optional step of configuring the server port using the `PORT` env var.
* An example `.env` file has been added to the project for reference.
* `.gitignore` file has been updated to ignore **ALL** `.env` files.