### PR TITLE
Fix: incorrect path resolution for nested product routes

### DIFF
--- a/src/routes/product.js
+++ b/src/routes/product.js
@@ -173,7 +173,11 @@ const { getFakeStoreData } = require("../db/fakeStoreData");
  */
 
 router.get("/{*splat}", (req, res, next) => {
-  const path = req.params.splat ? "products/" + req.params.splat : "products";
+  const splat = req.params.splat;
+
+  const productPath = Array.isArray(splat) ? splat.join("/") : splat;
+
+  const path = productPath ? "products/" + productPath : "products";
   const data = getFakeStoreData(path) || { error: "nodata", path };
 
   setTimeout(() => {


### PR DESCRIPTION
## Fix: incorrect path resolution for nested product routes

### Problem
After switching to `/{*splat}`, Express returns `req.params.splat`
as an array for nested routes.

Example:
GET /products/category/electronics

req.params.splat becomes:
["category", "electronics"]

This results in:
products/category,electronics

which causes `nodata` errors.

### Solution
Join splat array with "/" before constructing path.

### Result
/products/category/electronics now correctly resolves to:
products/category/electronics